### PR TITLE
female_bloom_capacity argument; support for maketrans in python2

### DIFF
--- a/discoverY.py
+++ b/discoverY.py
@@ -15,6 +15,9 @@ def main():
     parser.add_argument('--female_kmers_set', help='Use if female kmers set provided (defaults to False)',
                         action='store_true', required=False)
     parser.add_argument('--kmer_size', help='Set kmer size (defaults to 25)', required=False)
+    parser.add_argument("--female_bloom_capacity", type=int, help="If female BloomFilter is not provided, \
+    This sets the capacity of the bloom filter. This should be greater than the number of distinct kmers \
+    in female.fasta or female_kmers.")
 
     parser.add_argument('--mode', help="Set to run in femal_only mode or female+male mode. \
     In female_only mode, the proportion shared between each contig with a female reference is computed.\
@@ -38,6 +41,14 @@ def main():
 
     if args['female_bloom']:
         bloom_filt = True
+    elif args['female_bloom_capacity']:
+        try:
+            bf_capacity = int(args['female_bloom_capacity'])
+        except ValueError:
+            print("Error : female_bloom_capacity provided is not an integer")
+            kmers.exit_gracefully()
+    else:
+        bf_capacity = 3 * 1000 * 1000 * 1000
 
     print("Started DiscoverY")
 
@@ -48,10 +59,9 @@ def main():
     print("Mode", mode)
     # declare defaults
     print("Using default of k=25 and input folder='data'")
-    print("Please set bloom filter size before running this program")
     print("Shortlisting Y-contigs")
-    
-    classify_ctgs.classify_ctgs(k_size, bloom_filt, female_kmers, mode)
+
+    classify_ctgs.classify_ctgs(k_size, bloom_filt, bf_capacity, female_kmers, mode)
 
     print("DiscoverY completed successfully")
 

--- a/scripts/classify_ctgs.py
+++ b/scripts/classify_ctgs.py
@@ -8,16 +8,15 @@ from numpy import median
 
 
 
-def getbloomFilter(bf, fem_kmers, kmer_size):
+def getbloomFilter(bf, bf_capacity, fem_kmers, kmer_size):
     if bf:
         print("Opening Bloom Filter of k-mers from female")
         female_kmers_bf = BloomFilter.open("data/female.bloom")
         print("Done")
     else:
         print("Need to make Bloom Filter of k-mers from female")
-        bf_size = 3 * 1000 * 1000 * 1000
         bf_filename = "data/female.bloom"
-        female_kmers_bf = BloomFilter(bf_size, .001, bf_filename)
+        female_kmers_bf = BloomFilter(bf_capacity, .001, bf_filename)
 
         if fem_kmers: # if female kmers file exist
             female_kmers_file = "data/female_kmers"
@@ -138,8 +137,8 @@ def classify_fm_mode(kmer_size, female_kmers_bf):
     annotated_contigs.close()
     return
 
-def classify_ctgs(kmer_size, bf, fem_kmers, mode):
-    female_kmers_bf = getbloomFilter(bf, fem_kmers, kmer_size)
+def classify_ctgs(kmer_size, bf, bf_capacity, fem_kmers, mode):
+    female_kmers_bf = getbloomFilter(bf, bf_capacity, fem_kmers, kmer_size)
     if mode == "female+male":
         classify_fm_male_mode(kmer_size, female_kmers_bf)
     elif mode == "female_only":

--- a/scripts/kmers.py
+++ b/scripts/kmers.py
@@ -1,16 +1,21 @@
 from collections import defaultdict
-from Bio import SeqIO
-from pybloomfilter import BloomFilter
 import sys
 
 
 def exit_gracefully():
     sys.exit("^DiscoverY exited with error, please see the message above.^")
 
-
-def reverse_complement(seq):
-    complement_map = str.maketrans("ACGTNacgtn", "TGCANtgcan")
-    return seq[::-1].translate(complement_map)
+try:
+	# for python 3, where maketrans() is a function
+	from string import maketrans
+	complement_map = maketrans("ACGTNacgtn", "TGCANtgcan")
+	def reverse_complement(seq):
+	    return seq[::-1].translate(complement_map)
+except ImportError:
+	# for python 3, where maketrans() is a class function
+	def reverse_complement(seq):
+	    complement_map = str.maketrans("ACGTNacgtn", "TGCANtgcan")
+	    return seq[::-1].translate(complement_map)
 
 
 def test_valid_kmer_format(sample_line, kmer_size):


### PR DESCRIPTION
(1) Added a command line argument to set the female bloom filter capacity. This replaces the necessity of the user modifying to source code to accomplish this.

(2) Made the reverse_complement function definition adaptive, so that it should work in both python2 and python3.